### PR TITLE
Improve traces

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Npgsql" Version="7.0.4" />
     <PackageVersion Include="NSubstitute" Version="5.0.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.5.1" />
     <PackageVersion Include="Polly" Version="7.2.4" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />
     <PackageVersion Include="SpanJson" Version="4.0.1" />

--- a/src/Eventso.Subscription/Diagnostic.cs
+++ b/src/Eventso.Subscription/Diagnostic.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using OpenTelemetry.Trace;
 
 namespace Eventso.Subscription;
 
@@ -15,6 +16,8 @@ public static class Diagnostic
     {
         activity.SetStatus(ActivityStatusCode.Error, ex.Message)
             .SetCustomProperty("exception", ex);
+
+        activity.RecordException(ex);
 
         return activity;
     }

--- a/src/Eventso.Subscription/Diagnostic.cs
+++ b/src/Eventso.Subscription/Diagnostic.cs
@@ -18,4 +18,37 @@ public static class Diagnostic
 
         return activity;
     }
+
+    internal static RootActivityScope StartRooted(string name, ActivityKind kind = ActivityKind.Internal)
+    {
+        var previous = Activity.Current;
+        Activity.Current = null;
+
+        var newRoot = ActivitySource.StartActivity(name, kind);
+
+        return new RootActivityScope(newRoot, previous);
+    }
+
+    internal readonly struct RootActivityScope : IDisposable
+    {
+        public readonly Activity? Activity;
+
+        private readonly Activity? _previous;
+
+        public RootActivityScope(Activity? newRoot, Activity? previous)
+        {
+            Activity = newRoot;
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            Activity?.Dispose();
+
+            if (_previous is { } previous)
+            {
+                Activity.Current = previous;
+            }
+        }
+    }
 }

--- a/src/Eventso.Subscription/Eventso.Subscription.csproj
+++ b/src/Eventso.Subscription/Eventso.Subscription.csproj
@@ -7,6 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="OpenTelemetry.Api" />
 		<PackageReference Include="Polly" />
 	</ItemGroup>
 


### PR DESCRIPTION
- Report `kafka.consume` as rooted spans (independent traces) on consume loop iteration rather than the whole consume loop
- Properly report span duration and exceptions on `eventhandler.handle`
- Record exceptions using OpenTelemetry standard (here we can probably skip dependency and just bake RecordException into assembly instead)