### PR TITLE
Several task-related fixes

### DIFF
--- a/src/Eventso.Subscription.Kafka/KafkaConsumer.cs
+++ b/src/Eventso.Subscription.Kafka/KafkaConsumer.cs
@@ -157,8 +157,7 @@ public sealed class KafkaConsumer : ISubscriptionConsumer
                     activity?.SetTags(ex.ConsumerRecord);
                     var topic = ex.ConsumerRecord.Topic;
 
-                    if (_pausedTopicsObservers.Remove(topic, out var task))
-                        await task;
+                    await WaitPendingPause(topic);
 
                     PauseUntil(DelayedThrow(), topic);
 
@@ -182,12 +181,7 @@ public sealed class KafkaConsumer : ISubscriptionConsumer
         ConsumeResult<Guid, ConsumedMessage> result,
         CancellationToken token)
     {
-        if (_pausedTopicsObservers.Count > 0 &&
-            _pausedTopicsObservers.Remove(result.Topic, out var pausedTask))
-        {
-            _logger.LogInformation($"Waiting paused task for topic {result.Topic}");
-            await pausedTask;
-        }
+        await WaitPendingPause(result.Topic);
 
         var observer = observers.GetObserver(result.Topic);
 
@@ -209,6 +203,18 @@ public sealed class KafkaConsumer : ISubscriptionConsumer
 
         var resumeTask = ResumeOnComplete(waitingTask, topic);
         _pausedTopicsObservers.Add(topic, resumeTask);
+    }
+
+    private ValueTask WaitPendingPause(string topic)
+    {
+        if (_pausedTopicsObservers.Count > 0 &&
+            _pausedTopicsObservers.Remove(topic, out var pausedTask))
+        {
+            _logger.LogInformation("Waiting paused task for topic {Topic}", topic);
+            return new(pausedTask);
+        }
+
+        return default;
     }
 
     private async Task ResumeOnComplete(Task waitingTask, string topic)

--- a/src/Eventso.Subscription/Observing/Batch/BatchEventObserver.cs
+++ b/src/Eventso.Subscription/Observing/Batch/BatchEventObserver.cs
@@ -92,13 +92,14 @@ public sealed class BatchEventObserver<TEvent> : IObserver<TEvent>, IDisposable
 
     public void Dispose()
     {
+        if (_disposed)
+            return;
+
         _disposed = true;
         _buffer.Dispose();
         _batchChannel.Writer.TryComplete();
 
-        if (!_cancellationTokenSource.IsCancellationRequested)
-            _cancellationTokenSource.Cancel();
-
+        _cancellationTokenSource.Cancel();
         _cancellationTokenSource.Dispose();
 
         // drain potentially unobserved task exception

--- a/src/Eventso.Subscription/Observing/Batch/BatchEventObserver.cs
+++ b/src/Eventso.Subscription/Observing/Batch/BatchEventObserver.cs
@@ -100,6 +100,11 @@ public sealed class BatchEventObserver<TEvent> : IObserver<TEvent>, IDisposable
             _cancellationTokenSource.Cancel();
 
         _cancellationTokenSource.Dispose();
+
+        // drain potentially unobserved task exception
+        // it's observed elsewhere via _batchChannel's Writer.TryComplete(ex) and Reader.Completion
+        if (_batchHandlingTask.IsFaulted)
+            _ = _batchHandlingTask.Exception;
     }
 
     private async Task BeginBatchHandling()

--- a/src/Eventso.Subscription/Observing/Batch/Buffer.cs
+++ b/src/Eventso.Subscription/Observing/Batch/Buffer.cs
@@ -90,10 +90,12 @@ internal sealed class Buffer<TEvent> : IDisposable
 
     public void Dispose()
     {
+        if (_disposed)
+            return;
+
         _disposed = true;
 
-        if (!_tokenSource.IsCancellationRequested)
-            _tokenSource.Cancel();
+        _tokenSource.Cancel();
 
         _timer.Dispose();
         _channel.Writer.TryComplete();


### PR DESCRIPTION
* Prevent timeout timer leaks on timely observe task completion
  * this is big one, should be fixed asap
* Prevent unobserved exception to pop up on finalizer thread for batch handling task
  * perhaps it can be suppressed altogether since exception is propagated via channel
* Remove redundant check on CTS cancellation
  * no need to check for cancellation beforehand (cancel is idempotent and thread-safe, no-op if already cancelled)
* Semi-synchronous WaitPendingPause with logging
  * should be a net win in terms of state machine allocation